### PR TITLE
Added support for multiple file uploads

### DIFF
--- a/lib/carrierwave/encrypter_decrypter/openssl/aes.rb
+++ b/lib/carrierwave/encrypter_decrypter/openssl/aes.rb
@@ -3,27 +3,28 @@ module Openssl
     def self.encrypt_for(obj)
       begin
         model = obj.model
-        mounted_as = obj.mounted_as
         cipher = OpenSSL::Cipher.new("AES-#{Carrierwave::EncrypterDecrypter.configuration.key_size}-CBC")
         cipher.encrypt
-        iv = cipher.random_iv
+        iv = model.iv || cipher.random_iv
         model.iv = iv
-        key = cipher.random_key
+        cipher.iv = iv
+        key = model.key || cipher.random_key
         model.key = key
-        model.save!
+        cipher.key = key
+        model.save! if model.key_changed? || model.iv_changed?
 
         original_file_path = File.expand_path(obj.store_path, obj.root)
         encrypted_file_path = File.expand_path(obj.store_path, obj.root) + ".enc"
         buf = ""
         File.open(encrypted_file_path, "wb") do |outf|
-          File.open(model.send(mounted_as).path, "rb") do |inf|
+          File.open(obj.file.path, "rb") do |inf|
             while inf.read(4096, buf)
               outf << cipher.update(buf)
             end
             outf << cipher.final
           end
         end
-        File.unlink(model.send(mounted_as).path)
+        File.unlink(obj.file.path)
       rescue Exception => e
         puts "****************************#{e.message}"
         puts "****************************#{e.backtrace.inspect}"
@@ -33,15 +34,21 @@ module Openssl
     def self.decrypt_for(obj,opts)
       begin
         model = obj
-        mounted_as = opts[:mounted_as]
+        if opts.key?(:filename)
+          filename = opts[:filename]
+        else
+          mounted_as = opts[:mounted_as]
+          filename = obj.send(mounted_as).root + obj.send(mounted_as).url
+        end
+
         cipher = OpenSSL::Cipher.new("AES-#{Carrierwave::EncrypterDecrypter.configuration.key_size}-CBC")
         cipher.decrypt
         cipher.iv = model.iv
         cipher.key = model.key
         buf = ""
 
-        original_file_path =  obj.send(mounted_as).root + obj.send(mounted_as).url
-        encrypted_file_path =  obj.send(mounted_as).root + obj.send(mounted_as).url  + ".enc"
+        original_file_path =  filename
+        encrypted_file_path =  filename  + ".enc"
 
         File.open(original_file_path, "wb") do |outf|
           File.open(encrypted_file_path, "rb") do |inf|


### PR DESCRIPTION
See https://github.com/carrierwaveuploader/carrierwave#multiple-file-uploads

When uploading multiple files in original version, key and cipher get overwritten so only the last uploaded file can be decrypted.

Now new key and cipher are only created if not already existing. In decryption I added filename option support, so the specific file for decryption can be chosen.

Tested only for aes.
