### PR TITLE
Replace #url call to #path cause we have asset_host config option

### DIFF
--- a/lib/carrierwave/encrypter_decrypter/openssl/aes.rb
+++ b/lib/carrierwave/encrypter_decrypter/openssl/aes.rb
@@ -40,8 +40,8 @@ module Openssl
         cipher.key = model.key
         buf = ""
 
-        original_file_path =  obj.send(mounted_as).root + obj.send(mounted_as).url
-        encrypted_file_path =  obj.send(mounted_as).root + obj.send(mounted_as).url  + ".enc"
+        original_file_path = obj.send(mounted_as).path
+        encrypted_file_path = obj.send(mounted_as).path  + ".enc"
 
         File.open(original_file_path, "wb") do |outf|
           File.open(encrypted_file_path, "rb") do |inf|

--- a/lib/carrierwave/encrypter_decrypter/openssl/pkcs5.rb
+++ b/lib/carrierwave/encrypter_decrypter/openssl/pkcs5.rb
@@ -67,8 +67,8 @@ module Openssl
         key = OpenSSL::PKCS5.pbkdf2_hmac(pwd, salt, iter, key_len, digest)
         cipher.key = key
 
-        original_file_path =  obj.send(mounted_as).root + obj.send(mounted_as).url
-        encrypted_file_path =  obj.send(mounted_as).root + obj.send(mounted_as).url  + ".enc"
+        original_file_path = obj.send(mounted_as).path
+        encrypted_file_path = obj.send(mounted_as).path  + ".enc"
 
         buf = ""
 


### PR DESCRIPTION
**Story:** when I set `asset_host` option to carrierwave configuration through `config/initiaizers/carrierwave.rb`
```ruby
CarrierWave.configure do |config|
  config.asset_host = 'my://awesome.host'
end
```
My encrypted files feature was broken. Cause now it builds file path by root files storage + unique path by each file. But, `#url` method should returns remote path, and my correct path to decrypted files was broken with exceptions like this:
```
****************************No such file or directory @ rb_sysopen - /Users/user/projects/repo/public/Users/user/projects/repo/public/model/field/id/file_name.jpeg
```
As you can see part `/Users/user/projects/repo/public` duplicates.

I think that my PR solve this problem.